### PR TITLE
Fix merge breaking from upstream changes

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -320,13 +320,17 @@ const getImagesData = async (datasetId, datasetDetails, $axios) => {
     return {
       imagesData,
       scaffoldData,
-      tabsData
+      tabsData,
+      plotData,
+      videoData
     }
   } catch (error) {
     return {
       imagesData: [],
       scaffoldData,
-      tabsData
+      tabsData,
+      plotData: [],
+      videoData: []
     }
   }
 }
@@ -359,11 +363,13 @@ export default {
       $axios
     )
 
-    const { imagesData, scaffoldData, tabsData } = await getImagesData(
-      datasetId,
-      datasetDetails,
-      $axios
-    )
+    const {
+      imagesData,
+      scaffoldData,
+      tabsData,
+      plotData,
+      videoData
+    } = await getImagesData(datasetId, datasetDetails, $axios)
 
     return {
       entries: organEntries,


### PR DESCRIPTION
# Description

Upstream changes switched to asyn data for dataset details. Auto-merge seemed to not detect this.


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)


