### PR TITLE
Update plotvuer with mobile fix for small widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/mapintegratedvuer": "^0.1.26",
-    "@abi-software/plotvuer": "^0.2.26",
+    "@abi-software/plotvuer": "^0.2.31",
     "@abi-software/scaffoldvuer": "^0.1.43",
     "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",
     "@nuxtjs/axios": "^5.8.0",

--- a/pages/datasets/plotviewer/_id.vue
+++ b/pages/datasets/plotviewer/_id.vue
@@ -164,7 +164,6 @@ h1 {
     margin-top: 1.5rem;
     height: 90vh;
     max-width: calc(100% - 48px);
-    padding-left: 24px;
     @import '~@abi-software/plotvuer/dist/plotvuer'
   }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,10 @@
     vue "^2.6.10"
     vue-draggable-resizable "^2.2.0"
 
-"@abi-software/plotvuer@^0.2.26":
-  version "0.2.26"
-  resolved "https://registry.yarnpkg.com/@abi-software/plotvuer/-/plotvuer-0.2.26.tgz#58f251223b6f99a82099c0697a72b27f0a6628ba"
-  integrity sha512-EtedVuxpY3P3ZJ9tZz+ysBjnsjJzt9JZ82HSMBXfDa3zofCVv6P0lqAwoxTDg2fBDbJA6r4V4YLOjCOqnY+3Sg==
+"@abi-software/plotvuer@^0.2.31":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@abi-software/plotvuer/-/plotvuer-0.2.31.tgz#b31c6a72b46ff34171e09b0a80331d0163b05b52"
+  integrity sha512-kTCqoDJUhc2qL7vQuKl5U/LPgfQrfkZaUBiTHLwI6fodYY4eAOBRvkInMCpvBxKik9DAFAwTOysrPsHNWLvO/A==
   dependencies:
     core-js "^3.7.0"
     css-element-queries "^1.2.3"


### PR DESCRIPTION
# Description

Bug fix for plotvuer holding width of controls in mobile:
https://github.com/nih-sparc/sparc-app/pull/221

![image](https://user-images.githubusercontent.com/37255664/102848257-4425ed80-4479-11eb-9d1b-56e2781dd103.png)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested by using the mobile emulator in chrome.

View the heroku instance [here](https://sparc-science-add-plotvuer.herokuapp.com/datasets/plotviewer?dataset_version=6&dataset_id=29&file_path=29%2F6%2Ffiles%2Fderivative%2FHB-ICN-NegDDCT-data.csv)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

