### PR TITLE
Make sure window object is only use on client side

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -32,7 +32,7 @@ export default {
     this.uuid = this.$route.query.id;
     if (this.uuid) {
       let url = this.api + `map/getstate`;
-      fetch(url, {
+      await fetch(url, {
         method: 'POST',
         headers: {
           'Content-type': 'application/json',
@@ -106,8 +106,10 @@ export default {
     if (lastChar != '/') {
       this.api = this.api + '/';
     }
-    if (window)
-      this.prefix = window.location.origin + window.location.pathname;
+    if (process.client) {
+      if (window)
+        this.prefix = window.location.origin + window.location.pathname;
+    }
   },
 };
 </script>


### PR DESCRIPTION
# Description

A previous change causes a error when loading a link directed to the maps page, this pull request fixes it.


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pass testing and tested here - https://alan-wu-sparc-app.herokuapp.com/maps